### PR TITLE
Implement config generation workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+job-config/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
-# configs
-test
+# Config Generation Tool
+
+This repository demonstrates a simple configuration generation workflow using **Jinja2** templates and YAML overrides. Generated files are written into the `job-config` directory and should not be manually edited.
+
+## Structure
+```
+config-templates/   # Jinja2 templates
+config-overrides/   # Human-provided values
+job-config/         # Generated output
+```
+
+The `generate_configs.py` script walks all override files and renders the matching template to produce a final config file.
+
+## Usage
+Install dependencies and run the generator:
+```bash
+pip install jinja2 PyYAML
+python3 generate_configs.py
+```
+The script will populate `job-config` with rendered YAML files.

--- a/config-overrides/audience/experiment/yison-exp/AudiencePolicyTableGenerator/config.yml
+++ b/config-overrides/audience/experiment/yison-exp/AudiencePolicyTableGenerator/config.yml
@@ -1,0 +1,1 @@
+setting: "experiment"

--- a/config-overrides/audience/prod/RSMCalibrationInputDataGeneratorJob/config.yml
+++ b/config-overrides/audience/prod/RSMCalibrationInputDataGeneratorJob/config.yml
@@ -1,0 +1,2 @@
+param1: 10
+param2: 20

--- a/config-overrides/audience/test/yison-exp/RSMCalibrationInputDataGeneratorJob/config.yml
+++ b/config-overrides/audience/test/yison-exp/RSMCalibrationInputDataGeneratorJob/config.yml
@@ -1,0 +1,2 @@
+param1: 5
+param2: 15

--- a/config-templates/audience/AudiencePolicyTableGenerator/config.yml.j2
+++ b/config-templates/audience/AudiencePolicyTableGenerator/config.yml.j2
@@ -1,0 +1,4 @@
+job_name: AudiencePolicyTableGenerator
+environment: {{ environment }}
+setting: {{ setting }}
+

--- a/config-templates/audience/RSMCalibrationInputDataGeneratorJob/config.yml.j2
+++ b/config-templates/audience/RSMCalibrationInputDataGeneratorJob/config.yml.j2
@@ -1,0 +1,5 @@
+job_name: RSMCalibrationInputDataGeneratorJob
+environment: {{ environment }}
+param1: {{ param1 }}
+param2: {{ param2 }}
+

--- a/generate_configs.py
+++ b/generate_configs.py
@@ -1,0 +1,53 @@
+import os
+import yaml
+from jinja2 import Environment, FileSystemLoader
+
+TEMPLATE_ROOT = 'config-templates'
+OVERRIDE_ROOT = 'config-overrides'
+OUTPUT_ROOT = 'job-config'
+
+env = Environment(loader=FileSystemLoader(TEMPLATE_ROOT))
+
+
+def find_templates():
+    templates = {}
+    for root, _, files in os.walk(TEMPLATE_ROOT):
+        for f in files:
+            if f.endswith('.j2'):
+                rel = os.path.relpath(os.path.join(root, f), TEMPLATE_ROOT)
+                templates[rel] = env.get_template(rel)
+    return templates
+
+
+def generate_all():
+    templates = find_templates()
+    for root, _, files in os.walk(OVERRIDE_ROOT):
+        for fname in files:
+            if not fname.endswith('.yml'):
+                continue
+            override_path = os.path.join(root, fname)
+            rel_override = os.path.relpath(override_path, OVERRIDE_ROOT)
+            if not rel_override.startswith('audience' + os.sep):
+                continue
+            after_audience = rel_override[len('audience' + os.sep):]
+            for t_path in templates:
+                job_path = os.path.splitext(t_path)[0]  # e.g. audience/Job/config.yml
+                if not job_path.startswith('audience' + os.sep):
+                    continue
+                job_suffix = job_path[len('audience' + os.sep):]
+                if after_audience.endswith(job_suffix):
+                    env_path = after_audience[:-len(job_suffix)].rstrip(os.sep)
+                    out_path = os.path.join(OUTPUT_ROOT, 'audience', env_path, job_suffix)
+                    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+                    with open(override_path) as f:
+                        data = yaml.safe_load(f) or {}
+                    data.setdefault('environment', env_path)
+                    rendered = templates[t_path].render(**data)
+                    with open(out_path, 'w') as f:
+                        f.write(rendered)
+                    print(f'Wrote {out_path}')
+                    break
+
+
+if __name__ == '__main__':
+    generate_all()


### PR DESCRIPTION
## Summary
- create template and override directories for example jobs
- add generator script using Jinja2
- ignore generated output directory
- document usage in README

## Testing
- `python3 generate_configs.py`

------
https://chatgpt.com/codex/tasks/task_e_68499703d248832691f53a2ff04e1af2