### PR TITLE
Update config output folder and add defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-job-config/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Config Generation Tool
 
-This repository demonstrates a simple configuration generation workflow using **Jinja2** templates and YAML overrides. Generated files are written into the `job-config` directory and should not be manually edited.
+This repository demonstrates a simple configuration generation workflow using **Jinja2** templates and YAML overrides. Generated files are written into the `configs` directory and should not be manually edited.
 
 ## Structure
 ```
 config-templates/   # Jinja2 templates
 config-overrides/   # Human-provided values
-job-config/         # Generated output
+configs/            # Generated output
 ```
 
 The `generate_configs.py` script walks all override files and renders the matching template to produce a final config file.
@@ -17,4 +17,4 @@ Install dependencies and run the generator:
 pip install jinja2 PyYAML
 python3 generate_configs.py
 ```
-The script will populate `job-config` with rendered YAML files.
+The script will populate `configs` with rendered YAML files.

--- a/config-templates/audience/RSMCalibrationInputDataGeneratorJob/config.yml.j2
+++ b/config-templates/audience/RSMCalibrationInputDataGeneratorJob/config.yml.j2
@@ -1,5 +1,9 @@
 job_name: RSMCalibrationInputDataGeneratorJob
 environment: {{ environment }}
-param1: {{ param1 }}
-param2: {{ param2 }}
+model: "{{ model | default('RSMV2') }}"
+use_tmp_feature_generator: {{ use_tmp_feature_generator | default(false) | lower }}
+extra_sampling_threshold: {{ extra_sampling_threshold | default(0.05) }}
+rsm_v2_feature_source_path: "{{ rsm_v2_feature_source_path | default('/featuresV2.json') }}"
+rsm_v2_feature_dest_path: "{{ rsm_v2_feature_dest_path | default('s3a://thetradedesk-mlplatform-us-east-1/configdata/' ~ ttd_write_env ~ '/audience/schema/RSMV2/v=1/' ~ date_time.strftime(audience_version_date_format) ~ '/features.json') }}"
+sub_folder: "{{ sub_folder | default('Full') }}"
 

--- a/configs/audience/experiment/yison-exp/AudiencePolicyTableGenerator/config.yml
+++ b/configs/audience/experiment/yison-exp/AudiencePolicyTableGenerator/config.yml
@@ -1,0 +1,3 @@
+job_name: AudiencePolicyTableGenerator
+environment: experiment/yison-exp
+setting: experiment

--- a/configs/audience/prod/RSMCalibrationInputDataGeneratorJob/config.yml
+++ b/configs/audience/prod/RSMCalibrationInputDataGeneratorJob/config.yml
@@ -1,0 +1,8 @@
+job_name: RSMCalibrationInputDataGeneratorJob
+environment: prod
+model: "RSMV2"
+use_tmp_feature_generator: false
+extra_sampling_threshold: 0.05
+rsm_v2_feature_source_path: "/featuresV2.json"
+rsm_v2_feature_dest_path: "s3a://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/schema/RSMV2/v=1/20250612/features.json"
+sub_folder: "Full"

--- a/configs/audience/test/yison-exp/RSMCalibrationInputDataGeneratorJob/config.yml
+++ b/configs/audience/test/yison-exp/RSMCalibrationInputDataGeneratorJob/config.yml
@@ -1,0 +1,8 @@
+job_name: RSMCalibrationInputDataGeneratorJob
+environment: test/yison-exp
+model: "RSMV2"
+use_tmp_feature_generator: false
+extra_sampling_threshold: 0.05
+rsm_v2_feature_source_path: "/featuresV2.json"
+rsm_v2_feature_dest_path: "s3a://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/schema/RSMV2/v=1/20250612/features.json"
+sub_folder: "Full"

--- a/generate_configs.py
+++ b/generate_configs.py
@@ -1,12 +1,18 @@
 import os
+import datetime
 import yaml
 from jinja2 import Environment, FileSystemLoader
 
 TEMPLATE_ROOT = 'config-templates'
 OVERRIDE_ROOT = 'config-overrides'
-OUTPUT_ROOT = 'job-config'
+OUTPUT_ROOT = 'configs'
 
 env = Environment(loader=FileSystemLoader(TEMPLATE_ROOT))
+env.globals.update(
+    date_time=datetime.datetime.utcnow(),
+    audience_version_date_format='%Y%m%d',
+    ttd_write_env=os.environ.get('TTD_WRITE_ENV', 'prod'),
+)
 
 
 def find_templates():


### PR DESCRIPTION
## Summary
- rename generated output folder from `job-config` to `configs`
- remove `job-config` ignore rule
- include default values in RSMCalibrationInputDataGeneratorJob template
- expose extra Jinja globals so template renders correctly
- regenerate config outputs and update documentation

## Testing
- `pip install jinja2 PyYAML`
- `python3 generate_configs.py`

------
https://chatgpt.com/codex/tasks/task_e_684a621a15088326a1c62d46b9658e2d