### PR TITLE
Keep runtime date placeholders in configs

### DIFF
--- a/configs/audience/prod/RSMCalibrationInputDataGeneratorJob/config.yml
+++ b/configs/audience/prod/RSMCalibrationInputDataGeneratorJob/config.yml
@@ -4,5 +4,5 @@ model: "RSMV2"
 use_tmp_feature_generator: false
 extra_sampling_threshold: 0.05
 rsm_v2_feature_source_path: "/featuresV2.json"
-rsm_v2_feature_dest_path: "s3a://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/schema/RSMV2/v=1/20250612/features.json"
+rsm_v2_feature_dest_path: "s3a://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/schema/RSMV2/v=1/{{ date_time.strftime('%Y%m%d') }}/features.json"
 sub_folder: "Full"

--- a/configs/audience/test/yison-exp/RSMCalibrationInputDataGeneratorJob/config.yml
+++ b/configs/audience/test/yison-exp/RSMCalibrationInputDataGeneratorJob/config.yml
@@ -4,5 +4,5 @@ model: "RSMV2"
 use_tmp_feature_generator: false
 extra_sampling_threshold: 0.05
 rsm_v2_feature_source_path: "/featuresV2.json"
-rsm_v2_feature_dest_path: "s3a://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/schema/RSMV2/v=1/20250612/features.json"
+rsm_v2_feature_dest_path: "s3a://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/schema/RSMV2/v=1/{{ date_time.strftime('%Y%m%d') }}/features.json"
 sub_folder: "Full"

--- a/generate_configs.py
+++ b/generate_configs.py
@@ -3,13 +3,25 @@ import datetime
 import yaml
 from jinja2 import Environment, FileSystemLoader
 
+
+class DateTimePlaceholder:
+    """Object that renders Jinja placeholders for date_time."""
+
+    def __str__(self):
+        return "{{ date_time }}"
+
+    def strftime(self, fmt):
+        # Preserve the formatting expression for run time resolution
+        return f"{{{{ date_time.strftime('{fmt}') }}}}"
+
 TEMPLATE_ROOT = 'config-templates'
 OVERRIDE_ROOT = 'config-overrides'
 OUTPUT_ROOT = 'configs'
 
 env = Environment(loader=FileSystemLoader(TEMPLATE_ROOT))
 env.globals.update(
-    date_time=datetime.datetime.utcnow(),
+    # Use a placeholder so date_time is resolved at run time
+    date_time=DateTimePlaceholder(),
     audience_version_date_format='%Y%m%d',
     ttd_write_env=os.environ.get('TTD_WRITE_ENV', 'prod'),
 )


### PR DESCRIPTION
## Summary
- keep `{{date_time}}` placeholder unresolved when generating configs
- regenerate configs so runtime date formatting stays unresolved

## Testing
- `python3 generate_configs.py`

------
https://chatgpt.com/codex/tasks/task_e_684a676285248326a69413f1dec488f5