### PR TITLE
Fix windows clean command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ build:
 	python3 generate_configs.py
 
 clean:
-	rm -rf configs/*
+	python -c "import shutil, os; shutil.rmtree('configs', ignore_errors=True); os.makedirs('configs', exist_ok=True)"

--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ You can clean out generated files with:
 ```bash
 make clean
 ```
+The clean target uses Python so it works on Windows as well as Unix-like systems.


### PR DESCRIPTION
## Summary
- make `make clean` cross-platform by using Python
- clarify in README that clean works on Windows

## Testing
- `make clean`
- `make build > /tmp/build.log && tail -n 5 /tmp/build.log`
- `make clean`

------
https://chatgpt.com/codex/tasks/task_e_684a73a199548326ae755de1987808f0