### PR TITLE
Add Python 3 check and doc requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This repository demonstrates a simple configuration generation workflow using **Jinja2** templates and YAML overrides. Generated files are written into the `configs` directory and should not be manually edited.
 
+## Requirements
+
+* Python 3
+* `make`
+
 ## Structure
 ```
 config-templates/   # Jinja2 templates

--- a/generate_configs.py
+++ b/generate_configs.py
@@ -3,6 +3,11 @@ import sys
 import subprocess
 import importlib
 
+# Ensure the script is executed with Python 3
+if sys.version_info.major < 3:
+    sys.stderr.write("This script requires Python 3.\n")
+    sys.exit(1)
+
 
 def ensure_dependency(pkg, import_name=None):
     """Install the given package if the import fails."""


### PR DESCRIPTION
## Summary
- ensure `generate_configs.py` exits when run under Python 2
- document requirement for Python 3 and `make`

## Testing
- `make build`
- `make clean`
- `python3 generate_configs.py`

------
https://chatgpt.com/codex/tasks/task_e_684a74e3158883268a18a0e20a506af8