### PR TITLE
Add CalibrationInputDataGeneratorJob config

### DIFF
--- a/config-overrides/audience/experiment/yison-exp/CalibrationInputDataGeneratorJob/config.yml
+++ b/config-overrides/audience/experiment/yison-exp/CalibrationInputDataGeneratorJob/config.yml
@@ -1,0 +1,1 @@
+# Default config for CalibrationInputDataGeneratorJob in experiment

--- a/config-templates/audience/CalibrationInputDataGeneratorJob/config.yml.j2
+++ b/config-templates/audience/CalibrationInputDataGeneratorJob/config.yml.j2
@@ -1,0 +1,12 @@
+job_name: CalibrationInputDataGeneratorJob
+environment: {{ environment }}
+model: "{{ model | default('RSMV2') }}"
+tag: "{{ tag | default('Seed_None') }}"
+version: {{ version | default(1) }}
+lookBack: {{ lookBack | default(3) }}
+startDate: "{{ startDate | default('2025-02-13') }}"
+oosDataS3Bucket: "{{ oosDataS3Bucket | default('thetradedesk-mlplatform-us-east-1') }}"
+oosDataS3Path: "{{ oosDataS3Path | default('data/' ~ ttd_write_env ~ '/audience/RSMV2/Seed_None/v=1') }}"
+calibrationOutputDataS3Path: "{{ calibrationOutputDataS3Path | default('data/' ~ ttd_write_env ~ '/audience/RSMV2/Seed_None/v=1') }}"
+subFolderKey: "{{ subFolderKey | default('mixedForward') }}"
+subFolderValue: "{{ subFolderValue | default('Calibration') }}"

--- a/configs/audience/experiment/yison-exp/CalibrationInputDataGeneratorJob/config.yml
+++ b/configs/audience/experiment/yison-exp/CalibrationInputDataGeneratorJob/config.yml
@@ -1,0 +1,12 @@
+job_name: CalibrationInputDataGeneratorJob
+environment: experiment/yison-exp
+model: "RSMV2"
+tag: "Seed_None"
+version: 1
+lookBack: 3
+startDate: "2025-02-13"
+oosDataS3Bucket: "thetradedesk-mlplatform-us-east-1"
+oosDataS3Path: "data/prod/audience/RSMV2/Seed_None/v=1"
+calibrationOutputDataS3Path: "data/prod/audience/RSMV2/Seed_None/v=1"
+subFolderKey: "mixedForward"
+subFolderValue: "Calibration"

--- a/configs/audience/prod/CalibrationInputDataGeneratorJob/config.yml
+++ b/configs/audience/prod/CalibrationInputDataGeneratorJob/config.yml
@@ -1,0 +1,12 @@
+job_name: CalibrationInputDataGeneratorJob
+environment: prod
+model: "RSMV2"
+tag: "Seed_None"
+version: 1
+lookBack: 3
+startDate: "2025-02-13"
+oosDataS3Bucket: "thetradedesk-mlplatform-us-east-1"
+oosDataS3Path: "data/prod/audience/RSMV2/Seed_None/v=1"
+calibrationOutputDataS3Path: "data/prod/audience/RSMV2/Seed_None/v=1"
+subFolderKey: "mixedForward"
+subFolderValue: "Calibration"

--- a/configs/audience/test/yison-exp/CalibrationInputDataGeneratorJob/config.yml
+++ b/configs/audience/test/yison-exp/CalibrationInputDataGeneratorJob/config.yml
@@ -1,0 +1,12 @@
+job_name: CalibrationInputDataGeneratorJob
+environment: test/yison-exp
+model: "RSMV2"
+tag: "Seed_None"
+version: 1
+lookBack: 3
+startDate: "2025-02-13"
+oosDataS3Bucket: "thetradedesk-mlplatform-us-east-1"
+oosDataS3Path: "data/prod/audience/RSMV2/Seed_None/v=1"
+calibrationOutputDataS3Path: "data/prod/audience/RSMV2/Seed_None/v=1"
+subFolderKey: "mixedForward"
+subFolderValue: "Calibration"


### PR DESCRIPTION
## Summary
- add config template for CalibrationInputDataGeneratorJob
- add experiment override for new job
- generate configs for prod, test/yison-exp, and experiment/yison-exp

## Testing
- `python3 generate_configs.py`

------
https://chatgpt.com/codex/tasks/task_e_684ada5ec6e083269b8cd934e0bc59ae