### PR TITLE
Add template and configs for TDID dot product job

### DIFF
--- a/config-templates/audience/TdidEmbeddingDotProductGenerator/config.yml.j2
+++ b/config-templates/audience/TdidEmbeddingDotProductGenerator/config.yml.j2
@@ -1,0 +1,18 @@
+job_name: TdidEmbeddingDotProductGenerator
+environment: {{ environment }}
+salt: "{{ salt | default('TRM') }}"
+tdid_emb_path: "{{ tdid_emb_path | default('s3://thetradedesk-mlplatform-us-east-1/users/youjun.yuan/rsmv2/emb/agg_tdid/date=20250216/') }}"
+seed_emb_path: "{{ seed_emb_path | default('s3://thetradedesk-mlplatform-us-east-1/configdata/test/audience/embedding/RSMV2/RSMv2TestTreatment/v=1/20250216000000/embedding.parquet.gzip') }}"
+density_feature_path: "{{ density_feature_path | default('s3://thetradedesk-mlplatform-us-east-1/features/feature_store/prod/profiles/source=bidsimpression/index=TDID/job=DailyTDIDDensityScoreSplitJob/v=1/date=20250216/') }}"
+policy_table_path: "{{ policy_table_path | default('s3://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/policyTable/RSM/v=1/20250216000000/') }}"
+seed_id_path: "{{ seed_id_path | default('s3://thetradedesk-mlplatform-us-east-1/data/dev/audience/scores/seedids/v=2/date=20250216/') }}"
+out_path: "{{ out_path | default('s3://thetradedesk-mlplatform-us-east-1/data/dev/audience/scores/tdid2seedidV2/v=1/date=20250216/') }}"
+avail_path: "{{ avail_path | default('s3://thetradedesk-mlplatform-us-east-1/data/prodTest/audience/RSMV2/Availycp-dup_plus/v=2/20250216000000/') }}"
+seed_density_path: "{{ seed_density_path | default('s3://thetradedesk-mlplatform-us-east-1/features/feature_store/prodTest/profiles/source=bidsimpression/index=FeatureKeyValue/job=DailyDensityScoreReIndexingJob/config=SyntheticIdDensityScoreCategorized/date=20250216/') }}"
+density_split: {{ density_split | default(-1) }}
+density_limit: {{ density_limit | default(-1) }}
+tdid_limit: {{ tdid_limit | default(-1) }}
+debug: {{ debug | default(false) | lower }}
+partition: {{ partition | default(-1) }}
+EmbeddingSize: {{ EmbeddingSize | default(64) }}
+

--- a/configs/audience/experiment/yison-exp/TdidEmbeddingDotProductGenerator/config.yml
+++ b/configs/audience/experiment/yison-exp/TdidEmbeddingDotProductGenerator/config.yml
@@ -1,0 +1,17 @@
+job_name: TdidEmbeddingDotProductGenerator
+environment: experiment/yison-exp
+salt: "TRM"
+tdid_emb_path: "s3://thetradedesk-mlplatform-us-east-1/users/youjun.yuan/rsmv2/emb/agg_tdid/date=20250216/"
+seed_emb_path: "s3://thetradedesk-mlplatform-us-east-1/configdata/test/audience/embedding/RSMV2/RSMv2TestTreatment/v=1/20250216000000/embedding.parquet.gzip"
+density_feature_path: "s3://thetradedesk-mlplatform-us-east-1/features/feature_store/prod/profiles/source=bidsimpression/index=TDID/job=DailyTDIDDensityScoreSplitJob/v=1/date=20250216/"
+policy_table_path: "s3://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/policyTable/RSM/v=1/20250216000000/"
+seed_id_path: "s3://thetradedesk-mlplatform-us-east-1/data/dev/audience/scores/seedids/v=2/date=20250216/"
+out_path: "s3://thetradedesk-mlplatform-us-east-1/data/dev/audience/scores/tdid2seedidV2/v=1/date=20250216/"
+avail_path: "s3://thetradedesk-mlplatform-us-east-1/data/prodTest/audience/RSMV2/Availycp-dup_plus/v=2/20250216000000/"
+seed_density_path: "s3://thetradedesk-mlplatform-us-east-1/features/feature_store/prodTest/profiles/source=bidsimpression/index=FeatureKeyValue/job=DailyDensityScoreReIndexingJob/config=SyntheticIdDensityScoreCategorized/date=20250216/"
+density_split: -1
+density_limit: -1
+tdid_limit: -1
+debug: false
+partition: -1
+EmbeddingSize: 64

--- a/configs/audience/prod/TdidEmbeddingDotProductGenerator/config.yml
+++ b/configs/audience/prod/TdidEmbeddingDotProductGenerator/config.yml
@@ -1,0 +1,17 @@
+job_name: TdidEmbeddingDotProductGenerator
+environment: prod
+salt: "TRM"
+tdid_emb_path: "s3://thetradedesk-mlplatform-us-east-1/users/youjun.yuan/rsmv2/emb/agg_tdid/date=20250216/"
+seed_emb_path: "s3://thetradedesk-mlplatform-us-east-1/configdata/test/audience/embedding/RSMV2/RSMv2TestTreatment/v=1/20250216000000/embedding.parquet.gzip"
+density_feature_path: "s3://thetradedesk-mlplatform-us-east-1/features/feature_store/prod/profiles/source=bidsimpression/index=TDID/job=DailyTDIDDensityScoreSplitJob/v=1/date=20250216/"
+policy_table_path: "s3://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/policyTable/RSM/v=1/20250216000000/"
+seed_id_path: "s3://thetradedesk-mlplatform-us-east-1/data/dev/audience/scores/seedids/v=2/date=20250216/"
+out_path: "s3://thetradedesk-mlplatform-us-east-1/data/dev/audience/scores/tdid2seedidV2/v=1/date=20250216/"
+avail_path: "s3://thetradedesk-mlplatform-us-east-1/data/prodTest/audience/RSMV2/Availycp-dup_plus/v=2/20250216000000/"
+seed_density_path: "s3://thetradedesk-mlplatform-us-east-1/features/feature_store/prodTest/profiles/source=bidsimpression/index=FeatureKeyValue/job=DailyDensityScoreReIndexingJob/config=SyntheticIdDensityScoreCategorized/date=20250216/"
+density_split: -1
+density_limit: -1
+tdid_limit: -1
+debug: false
+partition: -1
+EmbeddingSize: 64

--- a/configs/audience/test/yison-exp/TdidEmbeddingDotProductGenerator/config.yml
+++ b/configs/audience/test/yison-exp/TdidEmbeddingDotProductGenerator/config.yml
@@ -1,0 +1,17 @@
+job_name: TdidEmbeddingDotProductGenerator
+environment: test/yison-exp
+salt: "TRM"
+tdid_emb_path: "s3://thetradedesk-mlplatform-us-east-1/users/youjun.yuan/rsmv2/emb/agg_tdid/date=20250216/"
+seed_emb_path: "s3://thetradedesk-mlplatform-us-east-1/configdata/test/audience/embedding/RSMV2/RSMv2TestTreatment/v=1/20250216000000/embedding.parquet.gzip"
+density_feature_path: "s3://thetradedesk-mlplatform-us-east-1/features/feature_store/prod/profiles/source=bidsimpression/index=TDID/job=DailyTDIDDensityScoreSplitJob/v=1/date=20250216/"
+policy_table_path: "s3://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/policyTable/RSM/v=1/20250216000000/"
+seed_id_path: "s3://thetradedesk-mlplatform-us-east-1/data/dev/audience/scores/seedids/v=2/date=20250216/"
+out_path: "s3://thetradedesk-mlplatform-us-east-1/data/dev/audience/scores/tdid2seedidV2/v=1/date=20250216/"
+avail_path: "s3://thetradedesk-mlplatform-us-east-1/data/prodTest/audience/RSMV2/Availycp-dup_plus/v=2/20250216000000/"
+seed_density_path: "s3://thetradedesk-mlplatform-us-east-1/features/feature_store/prodTest/profiles/source=bidsimpression/index=FeatureKeyValue/job=DailyDensityScoreReIndexingJob/config=SyntheticIdDensityScoreCategorized/date=20250216/"
+density_split: -1
+density_limit: -1
+tdid_limit: -1
+debug: false
+partition: -1
+EmbeddingSize: 64


### PR DESCRIPTION
## Summary
- add template for `TdidEmbeddingDotProductGenerator`
- generate configs for prod, test/yison-exp and experiment/yison-exp environments

## Testing
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_684aea71c1208326a1212beb01636ddf