### PR TITLE
Improve missing config error message

### DIFF
--- a/generate_configs.py
+++ b/generate_configs.py
@@ -102,10 +102,24 @@ def generate_all():
             try:
                 rendered = template.render(**data)
             except exceptions.UndefinedError as e:
-                print(
-                    f"Error generating {env_path}/{job_suffix}: {e}",
-                    file=sys.stderr,
-                )
+                message = str(e)
+                missing_key = None
+                if "'" in message:
+                    parts = message.split("'")
+                    if len(parts) >= 2:
+                        missing_key = parts[1]
+                if missing_key:
+                    print(
+                        f"Error generating {env_path}/{job_suffix}: "
+                        f"configuration '{missing_key}' is required but no value was provided "
+                        f"in {override_file}",
+                        file=sys.stderr,
+                    )
+                else:
+                    print(
+                        f"Error generating {env_path}/{job_suffix}: {message}",
+                        file=sys.stderr,
+                    )
                 continue
 
             os.makedirs(os.path.dirname(out_path), exist_ok=True)


### PR DESCRIPTION
## Summary
- clarify missing override details when rendering config templates fails

## Testing
- `make build`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_684f96a1871c832687a8c1aac0f729f5