### PR TITLE
Use partition name for write env

### DIFF
--- a/configs/experiment/yison-exp/audience/CalibrationInputDataGeneratorJob/config.yml
+++ b/configs/experiment/yison-exp/audience/CalibrationInputDataGeneratorJob/config.yml
@@ -6,7 +6,7 @@ version: 1
 lookBack: 3
 startDate: "2025-02-13"
 oosDataS3Bucket: "thetradedesk-mlplatform-us-east-1"
-oosDataS3Path: "data/prod/audience/RSMV2/Seed_None/v=1"
-calibrationOutputDataS3Path: "data/prod/audience/RSMV2/Seed_None/v=1"
+oosDataS3Path: "data/experiment/audience/RSMV2/Seed_None/v=1"
+calibrationOutputDataS3Path: "data/experiment/audience/RSMV2/Seed_None/v=1"
 subFolderKey: "mixedForward"
 subFolderValue: "Calibration"

--- a/configs/experiment/yison-exp/audience/EmbeddingMergeJob/config.yml
+++ b/configs/experiment/yison-exp/audience/EmbeddingMergeJob/config.yml
@@ -2,10 +2,10 @@ job_name: EmbeddingMergeJob
 environment: experiment/yison-exp
 model: "RSM"
 mlplatformS3Bucket: "thetradedesk-mlplatform-us-east-1"
-tmpNonSenEmbeddingDataS3Path: "configdata/prod/audience/embedding_temp/RSMV2/nonsensitive/v=1"
-tmpSenEmbeddingDataS3Path: "configdata/prod/audience/embedding_temp/RSMV2/sensitive/v=1"
-embeddingDataS3Path: "configdata/prod/audience/embedding/RSMV2/v=1"
-inferenceDataS3Path: "data/prod/audience/RSMV2/prediction"
+tmpNonSenEmbeddingDataS3Path: "configdata/experiment/audience/embedding_temp/RSMV2/nonsensitive/v=1"
+tmpSenEmbeddingDataS3Path: "configdata/experiment/audience/embedding_temp/RSMV2/sensitive/v=1"
+embeddingDataS3Path: "configdata/experiment/audience/embedding/RSMV2/v=1"
+inferenceDataS3Path: "data/experiment/audience/RSMV2/prediction"
 embeddingRecentVersion: "None"
 anchorStartDate: "2025-03-05"
 smoothFactor: 30.0

--- a/configs/experiment/yison-exp/audience/PopulationInputDataGeneratorJob/config.yml
+++ b/configs/experiment/yison-exp/audience/PopulationInputDataGeneratorJob/config.yml
@@ -2,8 +2,8 @@ job_name: PopulationInputDataGeneratorJob
 environment: experiment/yison-exp
 model: "RSMV2"
 inputDataS3Bucket: "thetradedesk-mlplatform-us-east-1"
-inputDataS3Path: "data/prod/audience/RSMV2/Imp_Seed_None/v=1"
-populationOutputData3Path: "data/prod/audience/RSMV2/Seed_None/v=1"
+inputDataS3Path: "data/experiment/audience/RSMV2/Imp_Seed_None/v=1"
+populationOutputData3Path: "data/experiment/audience/RSMV2/Seed_None/v=1"
 customInputDataPath: "None"
 subFolderKey: "split"
 subFolderValue: "Population"

--- a/configs/experiment/yison-exp/audience/RelevanceModelInputGenerator/config.yml
+++ b/configs/experiment/yison-exp/audience/RelevanceModelInputGenerator/config.yml
@@ -4,9 +4,9 @@ model: "RSMV2"
 use_tmp_feature_generator: false
 extra_sampling_threshold: 0.05
 rsm_v2_feature_source_path: "/featuresV2.json"
-rsm_v2_feature_dest_path: "s3a://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/schema/RSMV2/v=1/{{ date_time.strftime('%Y%m%d') }}/features.json"
+rsm_v2_feature_dest_path: "s3a://thetradedesk-mlplatform-us-east-1/configdata/experiment/audience/schema/RSMV2/v=1/{{ date_time.strftime('%Y%m%d') }}/features.json"
 sub_folder: "Full"
-opt_in_seed_empty_tag_path: "s3a://thetradedesk-mlplatform-us-east-1/data/prod/audience/RSMV2/Seed_None/v=1/{{ date_time.strftime('%Y%m%d') }}/_Full_EMPTY"
+opt_in_seed_empty_tag_path: "s3a://thetradedesk-mlplatform-us-east-1/data/experiment/audience/RSMV2/Seed_None/v=1/{{ date_time.strftime('%Y%m%d') }}/_Full_EMPTY"
 density_feature_read_path_without_slash: "profiles/source=bidsimpression/index=TDID/job=DailyTDIDDensityScoreSplitJob/v=1"
 sensitive_feature_columns: ""
 persist_holdout_set: true

--- a/configs/experiment/yison-exp/audience/TdidSeedScoreScale/config.yml
+++ b/configs/experiment/yison-exp/audience/TdidSeedScoreScale/config.yml
@@ -1,11 +1,11 @@
 job_name: TdidSeedScoreScale
 environment: experiment/yison-exp
 salt: "TRM"
-raw_score_path: "s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/scores/tdid2seedid_raw/v=1/date={{ date_time.strftime('%Y%m%d') }}/"
-seed_id_path: "s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/scores/seedids/v=2/date={{ date_time.strftime('%Y%m%d') }}/"
+raw_score_path: "s3://thetradedesk-mlplatform-us-east-1/data/experiment/audience/scores/tdid2seedid_raw/v=1/date={{ date_time.strftime('%Y%m%d') }}/"
+seed_id_path: "s3://thetradedesk-mlplatform-us-east-1/data/experiment/audience/scores/seedids/v=2/date={{ date_time.strftime('%Y%m%d') }}/"
 policy_table_path: "s3://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/policyTable/RSM/v=1/{{ date_time.strftime('%Y%m%d') }}000000/"
-out_path: "s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/scores/tdid2seedid/v=1/date={{ date_time.strftime('%Y%m%d') }}/"
-population_score_path: "s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/scores/seedpopulationscore/v=1/date={{ date_time.strftime('%Y%m%d') }}/"
+out_path: "s3://thetradedesk-mlplatform-us-east-1/data/experiment/audience/scores/tdid2seedid/v=1/date={{ date_time.strftime('%Y%m%d') }}/"
+population_score_path: "s3://thetradedesk-mlplatform-us-east-1/data/experiment/audience/scores/seedpopulationscore/v=1/date={{ date_time.strftime('%Y%m%d') }}/"
 smooth_factor: 30.0
 userLevelUpperCap: 1000000.0
 accuracy: 1000

--- a/generate_configs.py
+++ b/generate_configs.py
@@ -48,7 +48,6 @@ env.globals.update(
     # Use a placeholder so date_time is resolved at run time
     date_time=DateTimePlaceholder(),
     audience_version_date_format='%Y%m%d',
-    ttd_write_env=os.environ.get('TTD_WRITE_ENV', 'prod'),
 )
 
 
@@ -98,6 +97,10 @@ def generate_all():
                     data = yaml.safe_load(f) or {}
 
             data.setdefault('environment', env_path)
+            # Use the top-level override directory (e.g. 'prod', 'experiment',
+            # 'test') as the write environment for template paths.
+            partition = env_path.split('/')[0]
+            data.setdefault('ttd_write_env', partition)
             out_path = os.path.join(OUTPUT_ROOT, env_path, 'audience', job_suffix)
             try:
                 rendered = template.render(**data)


### PR DESCRIPTION
## Summary
- derive `ttd_write_env` from the top-level override directory rather than an environment variable
- regenerate example config output

## Testing
- `make build`

------
https://chatgpt.com/codex/tasks/task_e_684faaeac1708326a2270125041d25f2