### PR TITLE
Update RSMPolicyTable template

### DIFF
--- a/config-templates/audience/RSMPolicyTable/config.yml.j2
+++ b/config-templates/audience/RSMPolicyTable/config.yml.j2
@@ -1,6 +1,7 @@
 job_name: RSMPolicyTable
 environment: {{ environment }}
 model: "{{ model | default('RSMV2') }}"
+modelName: "{{ modelName | default('RSM') }}"
 storageCloud: "{{ storageCloud | default('AWS') }}"
 seedMetaDataRecentVersion: "{{ seedMetaDataRecentVersion | default(None) }}"
 seedMetadataS3Bucket: "{{ seedMetadataS3Bucket | default('ttd-datprd-us-east-1') }}"
@@ -13,8 +14,12 @@ policyTableResetSyntheticId: {{ policyTableResetSyntheticId | default(false) | l
 conversionLookBack: {{ conversionLookBack | default(5) }}
 expiredDays: {{ expiredDays | default(7) }}
 policyTableLookBack: {{ policyTableLookBack | default(3) }}
+activeAdvertiserLookBackDays: {{ activeAdvertiserLookBackDays | default(180) }}
+newSeedLookBackDays: {{ newSeedLookBackDays | default(7) }}
+userDownSampleHitPopulation: {{ userDownSampleHitPopulation | default(100000) }}
+lookBack: {{ lookBack | default(3) }}
 policyS3Bucket: "{{ policyS3Bucket | default('thetradedesk-mlplatform-us-east-1') }}"
-policyS3Path: "{{ policyS3Path | default('configdata/' ~ ttd_write_env ~ '/audience/policyTable/' ~ model ~ '/v=1') }}"
+policyS3Path: "{{ policyS3Path | default('configdata/' ~ ttd_write_env ~ '/audience/policyTable/' ~ (model | default('RSMV2')) ~ '/v=1') }}"
 maxVersionsToKeep: {{ maxVersionsToKeep | default(30) }}
 reuseAggregatedSeedIfPossible: {{ reuseAggregatedSeedIfPossible | default(true) | lower }}
 bidImpressionRepartitionNum: {{ bidImpressionRepartitionNum | default(4096) }}


### PR DESCRIPTION
## Summary
- add activeAdvertiserLookBackDays, newSeedLookBackDays, userDownSampleHitPopulation and lookBack to RSMPolicyTable
- include modelName field
- fix default for policyS3Path when model is unspecified

## Testing
- `make clean`
- `make build`

------
https://chatgpt.com/codex/tasks/task_e_684fc41788548326a4c81518393817f0