### PR TITLE
Remove hard‑coded group name

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ configs/            # Generated output
 ```
 
 Override files and generated configs are organized with the environment as the
-first directory level. For example, overrides for the `prod` environment live
-under `config-overrides/prod/audience/` and generated files are written to
-`configs/prod/audience/`.
+first directory level. Under each environment you can have one or more *group*
+directories that contain related jobs. For example, overrides for the `prod`
+environment might live under `config-overrides/prod/audience/` and the
+generated files would be written to `configs/prod/audience/`. Future groups
+such as `feature_store` or `kongming` can use the same pattern.
 
 Each job template provides two files: `behavioral_config.yml.j2` for the
 behavior-related settings and `outputs.yml.j2` for any output paths. Running the

--- a/config-templates/audience/Imp2BrModelInferenceDataGenerator/behavioral_config.yml.j2
+++ b/config-templates/audience/Imp2BrModelInferenceDataGenerator/behavioral_config.yml.j2
@@ -1,3 +1,3 @@
 environment: {{ environment }}
 bidImpressionsS3Path: "{{ bidImpressionsS3Path | default('prod/bidsimpressions/') }}"
-feature_path: "{{ feature_path | default('s3://thetradedesk-mlplatform-us-east-1/models/prod/RSM/full_model/' ~ date_time.strftime(audience_version_date_format) ~ '/features.json') }}"
+feature_path: "{{ feature_path | default('s3://thetradedesk-mlplatform-us-east-1/models/prod/RSM/full_model/' ~ date_time.strftime(version_date_format) ~ '/features.json') }}"

--- a/config-templates/audience/RelevanceModelInputGenerator/behavioral_config.yml.j2
+++ b/config-templates/audience/RelevanceModelInputGenerator/behavioral_config.yml.j2
@@ -3,10 +3,10 @@ model: "{{ model | default('RSMV2') }}"
 use_tmp_feature_generator: {{ use_tmp_feature_generator | default(false) | lower }}
 extra_sampling_threshold: {{ extra_sampling_threshold | default(0.05) }}
 rsm_v2_feature_source_path: "{{ rsm_v2_feature_source_path | default('/featuresV2.json') }}"
-rsm_v2_feature_dest_path: "{{ rsm_v2_feature_dest_path | default('s3a://thetradedesk-mlplatform-us-east-1/configdata/' ~ ttd_write_env ~ '/audience/schema/RSMV2/v=1/' ~ date_time.strftime(audience_version_date_format) ~ '/features.json') }}"
+rsm_v2_feature_dest_path: "{{ rsm_v2_feature_dest_path | default('s3a://thetradedesk-mlplatform-us-east-1/configdata/' ~ ttd_write_env ~ '/audience/schema/RSMV2/v=1/' ~ date_time.strftime(version_date_format) ~ '/features.json') }}"
 feature_store_read_env: "{{ feature_store_read_env | default(ttd_write_env) }}"
 sub_folder: "{{ sub_folder | default('Full') }}"
-opt_in_seed_empty_tag_path: "{{ opt_in_seed_empty_tag_path | default('s3a://thetradedesk-mlplatform-us-east-1/data/' ~ ttd_write_env ~ '/audience/RSMV2/Seed_None/v=1/' ~ date_time.strftime(audience_version_date_format) ~ '/_' ~ (sub_folder | default('Full')) ~ '_EMPTY') }}"
+opt_in_seed_empty_tag_path: "{{ opt_in_seed_empty_tag_path | default('s3a://thetradedesk-mlplatform-us-east-1/data/' ~ ttd_write_env ~ '/audience/RSMV2/Seed_None/v=1/' ~ date_time.strftime(version_date_format) ~ '/_' ~ (sub_folder | default('Full')) ~ '_EMPTY') }}"
 density_feature_read_path_without_slash: "{{ density_feature_read_path_without_slash | default('profiles/source=bidsimpression/index=TDID/job=DailyTDIDDensityScoreSplitJob/v=1') }}"
 sensitive_feature_columns: "{{ sensitive_feature_columns | default('') }}"
 persist_holdout_set: {{ persist_holdout_set | default(true) | lower }}

--- a/config-templates/audience/TdidSeedScoreScale/behavioral_config.yml.j2
+++ b/config-templates/audience/TdidSeedScoreScale/behavioral_config.yml.j2
@@ -1,10 +1,10 @@
 environment: {{ environment }}
 salt: "{{ salt | default('TRM') }}"
-raw_score_path: "{{ raw_score_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ ttd_write_env ~ '/audience/scores/tdid2seedid_raw/v=1/date=' ~ date_time.strftime(audience_version_date_format) ~ '/') }}"
-seed_id_path: "{{ seed_id_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ ttd_write_env ~ '/audience/scores/seedids/v=2/date=' ~ date_time.strftime(audience_version_date_format) ~ '/') }}"
-policy_table_path: "{{ policy_table_path | default('s3://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/policyTable/RSM/v=1/' ~ date_time.strftime(audience_version_date_format) ~ '000000/') }}"
-out_path: "{{ out_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ ttd_write_env ~ '/audience/scores/tdid2seedid/v=1/date=' ~ date_time.strftime(audience_version_date_format) ~ '/') }}"
-population_score_path: "{{ population_score_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ ttd_write_env ~ '/audience/scores/seedpopulationscore/v=1/date=' ~ date_time.strftime(audience_version_date_format) ~ '/') }}"
+raw_score_path: "{{ raw_score_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ ttd_write_env ~ '/audience/scores/tdid2seedid_raw/v=1/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
+seed_id_path: "{{ seed_id_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ ttd_write_env ~ '/audience/scores/seedids/v=2/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
+policy_table_path: "{{ policy_table_path | default('s3://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/policyTable/RSM/v=1/' ~ date_time.strftime(version_date_format) ~ '000000/') }}"
+out_path: "{{ out_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ ttd_write_env ~ '/audience/scores/tdid2seedid/v=1/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
+population_score_path: "{{ population_score_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ ttd_write_env ~ '/audience/scores/seedpopulationscore/v=1/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
 smooth_factor: {{ smooth_factor | default(30.0) }}
 userLevelUpperCap: {{ userLevelUpperCap | default(1000000.0) }}
 accuracy: {{ accuracy | default(1000) }}


### PR DESCRIPTION
## Summary
- generalize README to describe job groups
- remove hard-coded `audience` paths in generator
- rename `audience_version_date_format` -> `version_date_format`
- update templates to use `version_date_format`

## Testing
- `make clean`
- `make build`

------
https://chatgpt.com/codex/tasks/task_e_6851105e35cc8326ad7510b79292efba