### PR TITLE
Add build filters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
+
+group ?= all
+env ?= all
+job ?= all
+
 .PHONY: build clean
 
 build:
-	python3 generate_configs.py
+	python3 generate_configs.py group=$(group) env=$(env) job=$(job)
 
 clean:
 	python -c "import shutil, os; shutil.rmtree('configs', ignore_errors=True); os.makedirs('configs', exist_ok=True)"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ Run the generator:
 ```bash
 make build
 ```
+The Makefile passes `group`, `env` and `job` parameters to
+`generate_configs.py`. They default to `all`, so the above command
+generates every configuration.
+You can also restrict the generation to a specific group, environment or job.
+Each argument is required but may be set to `all` to include everything under
+that category.
+```bash
+make build group=audience env=prod job=CalibrationInputDataGeneratorJob
+```
 The `generate_configs.py` script automatically installs `Jinja2` and `PyYAML` if they
 are missing. The `build` target runs the script and populates `configs` with rendered YAML files.
 You can clean out generated files with:


### PR DESCRIPTION
## Summary
- require `group`, `env` and `job` parameters for `generate_configs.py`
- ignore lower-level filters if a higher level is `all`
- set default parameter values in the Makefile
- document required parameters in README

## Testing
- `make clean`
- `make build`
- `make build group=audience env=prod job=CalibrationInputDataGeneratorJob`
- `make build group=all env=prod job=CalibrationInputDataGeneratorJob`
- `python3 generate_configs.py` *(fails as expected)*

------
https://chatgpt.com/codex/tasks/task_e_685114facdb08326bea0e2f766fbdab1