### PR TITLE
Move write env paths to outputs templates

### DIFF
--- a/config-templates/audience/CalibrationInputDataGeneratorJob/behavioral_config.yml.j2
+++ b/config-templates/audience/CalibrationInputDataGeneratorJob/behavioral_config.yml.j2
@@ -8,6 +8,5 @@ version: {{ version | default(1) }}
 lookBack: {{ lookBack | default(3) }}
 startDate: "{{ startDate | default('2025-02-13') }}"
 oosDataS3Bucket: "{{ oosDataS3Bucket | default('thetradedesk-mlplatform-us-east-1') }}"
-oosDataS3Path: "{{ oosDataS3Path | default('data/' ~ ttd_write_env ~ '/audience/RSMV2/Seed_None/v=1') }}"
 subFolderKey: "{{ subFolderKey | default('mixedForward') }}"
 subFolderValue: "{{ subFolderValue | default('Calibration') }}"

--- a/config-templates/audience/CalibrationInputDataGeneratorJob/outputs.yml.j2
+++ b/config-templates/audience/CalibrationInputDataGeneratorJob/outputs.yml.j2
@@ -1,1 +1,2 @@
-calibrationOutputDataS3Path: "{{ calibrationOutputDataS3Path | default('data/' ~ ttd_write_env ~ '/audience/RSMV2/Seed_None/v=1') }}"
+oosDataS3Path: "{{ oosDataS3Path | default('data/' ~ data_write_partition ~ '/audience/RSMV2/Seed_None/v=1') }}"
+calibrationOutputDataS3Path: "{{ calibrationOutputDataS3Path | default('data/' ~ data_write_partition ~ '/audience/RSMV2/Seed_None/v=1') }}"

--- a/config-templates/audience/EmbeddingMergeJob/behavioral_config.yml.j2
+++ b/config-templates/audience/EmbeddingMergeJob/behavioral_config.yml.j2
@@ -4,10 +4,6 @@ experimentName: {{ experimentName }}
 {% endif %}
 model: "{{ model | default('RSM') }}"
 mlplatformS3Bucket: "{{ mlplatformS3Bucket | default('thetradedesk-mlplatform-us-east-1') }}"
-tmpNonSenEmbeddingDataS3Path: "{{ tmpNonSenEmbeddingDataS3Path | default('configdata/' ~ ttd_write_env ~ '/audience/embedding_temp/RSMV2/nonsensitive/v=1') }}"
-tmpSenEmbeddingDataS3Path: "{{ tmpSenEmbeddingDataS3Path | default('configdata/' ~ ttd_write_env ~ '/audience/embedding_temp/RSMV2/sensitive/v=1') }}"
-embeddingDataS3Path: "{{ embeddingDataS3Path | default('configdata/' ~ ttd_write_env ~ '/audience/embedding/RSMV2/v=1') }}"
-inferenceDataS3Path: "{{ inferenceDataS3Path | default('data/' ~ ttd_write_env ~ '/audience/RSMV2/prediction') }}"
 embeddingRecentVersion: "{{ embeddingRecentVersion | default(None) }}"
 anchorStartDate: "{{ anchorStartDate | default('2025-03-05') }}"
 smoothFactor: {{ smoothFactor | default(30.0) }}

--- a/config-templates/audience/EmbeddingMergeJob/outputs.yml.j2
+++ b/config-templates/audience/EmbeddingMergeJob/outputs.yml.j2
@@ -1,1 +1,4 @@
-{}
+tmpNonSenEmbeddingDataS3Path: "{{ tmpNonSenEmbeddingDataS3Path | default('configdata/' ~ data_write_partition ~ '/audience/embedding_temp/RSMV2/nonsensitive/v=1') }}"
+tmpSenEmbeddingDataS3Path: "{{ tmpSenEmbeddingDataS3Path | default('configdata/' ~ data_write_partition ~ '/audience/embedding_temp/RSMV2/sensitive/v=1') }}"
+embeddingDataS3Path: "{{ embeddingDataS3Path | default('configdata/' ~ data_write_partition ~ '/audience/embedding/RSMV2/v=1') }}"
+inferenceDataS3Path: "{{ inferenceDataS3Path | default('data/' ~ data_write_partition ~ '/audience/RSMV2/prediction') }}"

--- a/config-templates/audience/PopulationInputDataGeneratorJob/behavioral_config.yml.j2
+++ b/config-templates/audience/PopulationInputDataGeneratorJob/behavioral_config.yml.j2
@@ -4,8 +4,6 @@ experimentName: {{ experimentName }}
 {% endif %}
 model: "{{ model | default('RSMV2') }}"
 inputDataS3Bucket: "{{ inputDataS3Bucket | default('thetradedesk-mlplatform-us-east-1') }}"
-inputDataS3Path: "{{ inputDataS3Path | default('data/' ~ ttd_write_env ~ '/audience/RSMV2/Imp_Seed_None/v=1') }}"
-populationOutputData3Path: "{{ populationOutputData3Path | default('data/' ~ ttd_write_env ~ '/audience/RSMV2/Seed_None/v=1') }}"
 customInputDataPath: "{{ customInputDataPath | default(None) }}"
 subFolderKey: "{{ subFolderKey | default('split') }}"
 subFolderValue: "{{ subFolderValue | default('Population') }}"

--- a/config-templates/audience/PopulationInputDataGeneratorJob/outputs.yml.j2
+++ b/config-templates/audience/PopulationInputDataGeneratorJob/outputs.yml.j2
@@ -1,1 +1,2 @@
-{}
+inputDataS3Path: "{{ inputDataS3Path | default('data/' ~ data_write_partition ~ '/audience/RSMV2/Imp_Seed_None/v=1') }}"
+populationOutputData3Path: "{{ populationOutputData3Path | default('data/' ~ data_write_partition ~ '/audience/RSMV2/Seed_None/v=1') }}"

--- a/config-templates/audience/RSMPolicyTable/behavioral_config.yml.j2
+++ b/config-templates/audience/RSMPolicyTable/behavioral_config.yml.j2
@@ -21,7 +21,6 @@ newSeedLookBackDays: {{ newSeedLookBackDays | default(7) }}
 userDownSampleHitPopulation: {{ userDownSampleHitPopulation | default(100000) }}
 lookBack: {{ lookBack | default(3) }}
 policyS3Bucket: "{{ policyS3Bucket | default('thetradedesk-mlplatform-us-east-1') }}"
-policyS3Path: "{{ policyS3Path | default('configdata/' ~ ttd_write_env ~ '/audience/policyTable/' ~ (model | default('RSMV2')) ~ '/v=1') }}"
 maxVersionsToKeep: {{ maxVersionsToKeep | default(30) }}
 reuseAggregatedSeedIfPossible: {{ reuseAggregatedSeedIfPossible | default(true) | lower }}
 bidImpressionRepartitionNum: {{ bidImpressionRepartitionNum | default(4096) }}

--- a/config-templates/audience/RSMPolicyTable/outputs.yml.j2
+++ b/config-templates/audience/RSMPolicyTable/outputs.yml.j2
@@ -1,1 +1,1 @@
-{}
+policyS3Path: "{{ policyS3Path | default('configdata/' ~ data_write_partition ~ '/audience/policyTable/' ~ (model | default('RSMV2')) ~ '/v=1') }}"

--- a/config-templates/audience/RelevanceModelInputGenerator/behavioral_config.yml.j2
+++ b/config-templates/audience/RelevanceModelInputGenerator/behavioral_config.yml.j2
@@ -6,10 +6,7 @@ model: "{{ model | default('RSMV2') }}"
 use_tmp_feature_generator: {{ use_tmp_feature_generator | default(false) | lower }}
 extra_sampling_threshold: {{ extra_sampling_threshold | default(0.05) }}
 rsm_v2_feature_source_path: "{{ rsm_v2_feature_source_path | default('/featuresV2.json') }}"
-rsm_v2_feature_dest_path: "{{ rsm_v2_feature_dest_path | default('s3a://thetradedesk-mlplatform-us-east-1/configdata/' ~ ttd_write_env ~ '/audience/schema/RSMV2/v=1/' ~ date_time.strftime(version_date_format) ~ '/features.json') }}"
-feature_store_read_env: "{{ feature_store_read_env | default(ttd_write_env) }}"
 sub_folder: "{{ sub_folder | default('Full') }}"
-opt_in_seed_empty_tag_path: "{{ opt_in_seed_empty_tag_path | default('s3a://thetradedesk-mlplatform-us-east-1/data/' ~ ttd_write_env ~ '/audience/RSMV2/Seed_None/v=1/' ~ date_time.strftime(version_date_format) ~ '/_' ~ (sub_folder | default('Full')) ~ '_EMPTY') }}"
 density_feature_read_path_without_slash: "{{ density_feature_read_path_without_slash | default('profiles/source=bidsimpression/index=TDID/job=DailyTDIDDensityScoreSplitJob/v=1') }}"
 sensitive_feature_columns: "{{ sensitive_feature_columns | default('') }}"
 persist_holdout_set: {{ persist_holdout_set | default(true) | lower }}

--- a/config-templates/audience/RelevanceModelInputGenerator/outputs.yml.j2
+++ b/config-templates/audience/RelevanceModelInputGenerator/outputs.yml.j2
@@ -1,1 +1,3 @@
-{}
+rsm_v2_feature_dest_path: "{{ rsm_v2_feature_dest_path | default('s3a://thetradedesk-mlplatform-us-east-1/configdata/' ~ data_write_partition ~ '/audience/schema/RSMV2/v=1/' ~ date_time.strftime(version_date_format) ~ '/features.json') }}"
+feature_store_read_env: "{{ feature_store_read_env | default(data_write_partition) }}"
+opt_in_seed_empty_tag_path: "{{ opt_in_seed_empty_tag_path | default('s3a://thetradedesk-mlplatform-us-east-1/data/' ~ data_write_partition ~ '/audience/RSMV2/Seed_None/v=1/' ~ date_time.strftime(version_date_format) ~ '/_' ~ (sub_folder | default('Full')) ~ '_EMPTY') }}"

--- a/config-templates/audience/TdidSeedScoreScale/behavioral_config.yml.j2
+++ b/config-templates/audience/TdidSeedScoreScale/behavioral_config.yml.j2
@@ -3,11 +3,7 @@ environment: {{ environment }}
 experimentName: {{ experimentName }}
 {% endif %}
 salt: "{{ salt | default('TRM') }}"
-raw_score_path: "{{ raw_score_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ ttd_write_env ~ '/audience/scores/tdid2seedid_raw/v=1/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
-seed_id_path: "{{ seed_id_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ ttd_write_env ~ '/audience/scores/seedids/v=2/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
 policy_table_path: "{{ policy_table_path | default('s3://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/policyTable/RSM/v=1/' ~ date_time.strftime(version_date_format) ~ '000000/') }}"
-out_path: "{{ out_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ ttd_write_env ~ '/audience/scores/tdid2seedid/v=1/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
-population_score_path: "{{ population_score_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ ttd_write_env ~ '/audience/scores/seedpopulationscore/v=1/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
 smooth_factor: {{ smooth_factor | default(30.0) }}
 userLevelUpperCap: {{ userLevelUpperCap | default(1000000.0) }}
 accuracy: {{ accuracy | default(1000) }}

--- a/config-templates/audience/TdidSeedScoreScale/outputs.yml.j2
+++ b/config-templates/audience/TdidSeedScoreScale/outputs.yml.j2
@@ -1,1 +1,4 @@
-{}
+raw_score_path: "{{ raw_score_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_write_partition ~ '/audience/scores/tdid2seedid_raw/v=1/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
+seed_id_path: "{{ seed_id_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_write_partition ~ '/audience/scores/seedids/v=2/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
+out_path: "{{ out_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_write_partition ~ '/audience/scores/tdid2seedid/v=1/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
+population_score_path: "{{ population_score_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_write_partition ~ '/audience/scores/seedpopulationscore/v=1/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"

--- a/generate_configs.py
+++ b/generate_configs.py
@@ -160,10 +160,13 @@ def generate_all(env_filter='all', exp_filter='all'):
                     data.setdefault('experimentName', exp_name)
                 else:
                     data.pop('experimentName', None)
-                # Use the top-level directory (e.g. 'prod', 'experiment', 'test')
-                # as the write environment for template paths.
-                partition = env_name
-                data.setdefault('ttd_write_env', partition)
+                # Default partition for writing output data. Combine the
+                # environment and experiment name when available.
+                if exp_name:
+                    partition = f"{env_name}/{exp_name}"
+                else:
+                    partition = env_name
+                data.setdefault('data_write_partition', partition)
                 out_dir = os.path.join(OUTPUT_ROOT, env_path, group, job_name)
                 os.makedirs(out_dir, exist_ok=True)
                 out_path = os.path.join(out_dir, filename)


### PR DESCRIPTION
## Summary
- rename `ttd_write_env` to `data_write_partition`
- set default partition in `generate_configs.py`
- move all write-path config items from behavioural templates to `outputs.yml.j2`

## Testing
- `make clean >/dev/null`
- `make build env=prod >/dev/null`
- `make build env=experiment exp=yison-exp >/tmp/make_build2.log && tail -n 20 /tmp/make_build2.log`

------
https://chatgpt.com/codex/tasks/task_e_685cb9efcf248326877913f50aecef6d