### PR TITLE
Fix CalibrationInputDataGenerator output variables

### DIFF
--- a/config-templates/audience/CalibrationInputDataGeneratorJob/outputs.yml.j2
+++ b/config-templates/audience/CalibrationInputDataGeneratorJob/outputs.yml.j2
@@ -1,2 +1,1 @@
-oosDataS3Path: "{{ oosDataS3Path | default('data/' ~ data_write_partition ~ '/audience/RSMV2/Seed_None/v=1') }}"
-calibrationOutputDataS3Path: "{{ calibrationOutputDataS3Path | default('data/' ~ data_write_partition ~ '/audience/RSMV2/Seed_None/v=1') }}"
+calibrationOutputDataS3Path: "{{ calibrationOutputDataS3Path | default('data/' ~ data_namespace ~ '/audience/RSMV2/Seed_None/v=1') }}"

--- a/config-templates/audience/EmbeddingMergeJob/behavioral_config.yml.j2
+++ b/config-templates/audience/EmbeddingMergeJob/behavioral_config.yml.j2
@@ -11,3 +11,6 @@ locationFactor: {{ locationFactor | default(0.8) }}
 baselineHitRate: {{ baselineHitRate | default(1E-8) }}
 recursiveWeight: {{ recursiveWeight | default(0.1) }}
 writeMode: "{{ writeMode | default('overwrite') }}"
+tmpNonSenEmbeddingDataS3Path: "{{ tmpNonSenEmbeddingDataS3Path | default('configdata/' ~ data_namespace ~ '/audience/embedding_temp/RSMV2/nonsensitive/v=1') }}"
+tmpSenEmbeddingDataS3Path: "{{ tmpSenEmbeddingDataS3Path | default('configdata/' ~ data_namespace ~ '/audience/embedding_temp/RSMV2/sensitive/v=1') }}"
+inferenceDataS3Path: "{{ inferenceDataS3Path | default('data/' ~ data_namespace ~ '/audience/RSMV2/prediction') }}"

--- a/config-templates/audience/EmbeddingMergeJob/outputs.yml.j2
+++ b/config-templates/audience/EmbeddingMergeJob/outputs.yml.j2
@@ -1,4 +1,1 @@
-tmpNonSenEmbeddingDataS3Path: "{{ tmpNonSenEmbeddingDataS3Path | default('configdata/' ~ data_write_partition ~ '/audience/embedding_temp/RSMV2/nonsensitive/v=1') }}"
-tmpSenEmbeddingDataS3Path: "{{ tmpSenEmbeddingDataS3Path | default('configdata/' ~ data_write_partition ~ '/audience/embedding_temp/RSMV2/sensitive/v=1') }}"
-embeddingDataS3Path: "{{ embeddingDataS3Path | default('configdata/' ~ data_write_partition ~ '/audience/embedding/RSMV2/v=1') }}"
-inferenceDataS3Path: "{{ inferenceDataS3Path | default('data/' ~ data_write_partition ~ '/audience/RSMV2/prediction') }}"
+embeddingDataS3Path: "{{ embeddingDataS3Path | default('configdata/' ~ data_namespace ~ '/audience/embedding/RSMV2/v=1') }}"

--- a/config-templates/audience/PopulationInputDataGeneratorJob/outputs.yml.j2
+++ b/config-templates/audience/PopulationInputDataGeneratorJob/outputs.yml.j2
@@ -1,2 +1,2 @@
-inputDataS3Path: "{{ inputDataS3Path | default('data/' ~ data_write_partition ~ '/audience/RSMV2/Imp_Seed_None/v=1') }}"
-populationOutputData3Path: "{{ populationOutputData3Path | default('data/' ~ data_write_partition ~ '/audience/RSMV2/Seed_None/v=1') }}"
+inputDataS3Path: "{{ inputDataS3Path | default('data/' ~ data_namespace ~ '/audience/RSMV2/Imp_Seed_None/v=1') }}"
+populationOutputData3Path: "{{ populationOutputData3Path | default('data/' ~ data_namespace ~ '/audience/RSMV2/Seed_None/v=1') }}"

--- a/config-templates/audience/RSMPolicyTable/outputs.yml.j2
+++ b/config-templates/audience/RSMPolicyTable/outputs.yml.j2
@@ -1,1 +1,1 @@
-policyS3Path: "{{ policyS3Path | default('configdata/' ~ data_write_partition ~ '/audience/policyTable/' ~ (model | default('RSMV2')) ~ '/v=1') }}"
+policyS3Path: "{{ policyS3Path | default('configdata/' ~ data_namespace ~ '/audience/policyTable/' ~ (model | default('RSMV2')) ~ '/v=1') }}"

--- a/config-templates/audience/RelevanceModelInputGenerator/outputs.yml.j2
+++ b/config-templates/audience/RelevanceModelInputGenerator/outputs.yml.j2
@@ -1,3 +1,3 @@
-rsm_v2_feature_dest_path: "{{ rsm_v2_feature_dest_path | default('s3a://thetradedesk-mlplatform-us-east-1/configdata/' ~ data_write_partition ~ '/audience/schema/RSMV2/v=1/' ~ date_time.strftime(version_date_format) ~ '/features.json') }}"
-feature_store_read_env: "{{ feature_store_read_env | default(data_write_partition) }}"
-opt_in_seed_empty_tag_path: "{{ opt_in_seed_empty_tag_path | default('s3a://thetradedesk-mlplatform-us-east-1/data/' ~ data_write_partition ~ '/audience/RSMV2/Seed_None/v=1/' ~ date_time.strftime(version_date_format) ~ '/_' ~ (sub_folder | default('Full')) ~ '_EMPTY') }}"
+rsm_v2_feature_dest_path: "{{ rsm_v2_feature_dest_path | default('s3a://thetradedesk-mlplatform-us-east-1/configdata/' ~ data_namespace ~ '/audience/schema/RSMV2/v=1/' ~ date_time.strftime(version_date_format) ~ '/features.json') }}"
+feature_store_read_env: "{{ feature_store_read_env | default(data_namespace) }}"
+opt_in_seed_empty_tag_path: "{{ opt_in_seed_empty_tag_path | default('s3a://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/RSMV2/Seed_None/v=1/' ~ date_time.strftime(version_date_format) ~ '/_' ~ (sub_folder | default('Full')) ~ '_EMPTY') }}"

--- a/config-templates/audience/TdidSeedScoreScale/outputs.yml.j2
+++ b/config-templates/audience/TdidSeedScoreScale/outputs.yml.j2
@@ -1,4 +1,4 @@
-raw_score_path: "{{ raw_score_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_write_partition ~ '/audience/scores/tdid2seedid_raw/v=1/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
-seed_id_path: "{{ seed_id_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_write_partition ~ '/audience/scores/seedids/v=2/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
-out_path: "{{ out_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_write_partition ~ '/audience/scores/tdid2seedid/v=1/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
-population_score_path: "{{ population_score_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_write_partition ~ '/audience/scores/seedpopulationscore/v=1/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
+raw_score_path: "{{ raw_score_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/tdid2seedid_raw/v=1/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
+seed_id_path: "{{ seed_id_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/seedids/v=2/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
+out_path: "{{ out_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/tdid2seedid/v=1/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
+population_score_path: "{{ population_score_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/seedpopulationscore/v=1/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"

--- a/configs/experiment/yison-exp/audience/CalibrationInputDataGeneratorJob/outputs.yml
+++ b/configs/experiment/yison-exp/audience/CalibrationInputDataGeneratorJob/outputs.yml
@@ -1,2 +1,1 @@
-oosDataS3Path: data/experiment/yison-exp/audience/RSMV2/Seed_None/v=1
 calibrationOutputDataS3Path: data/experiment/yison-exp/audience/RSMV2/Seed_None/v=1

--- a/configs/experiment/yison-exp/audience/EmbeddingMergeJob/behavioral_config.yml
+++ b/configs/experiment/yison-exp/audience/EmbeddingMergeJob/behavioral_config.yml
@@ -9,3 +9,6 @@ locationFactor: 0.8
 baselineHitRate: 1e-08
 recursiveWeight: 0.1
 writeMode: overwrite
+tmpNonSenEmbeddingDataS3Path: configdata/experiment/yison-exp/audience/embedding_temp/RSMV2/nonsensitive/v=1
+tmpSenEmbeddingDataS3Path: configdata/experiment/yison-exp/audience/embedding_temp/RSMV2/sensitive/v=1
+inferenceDataS3Path: data/experiment/yison-exp/audience/RSMV2/prediction

--- a/configs/experiment/yison-exp/audience/EmbeddingMergeJob/outputs.yml
+++ b/configs/experiment/yison-exp/audience/EmbeddingMergeJob/outputs.yml
@@ -1,4 +1,1 @@
-tmpNonSenEmbeddingDataS3Path: configdata/experiment/yison-exp/audience/embedding_temp/RSMV2/nonsensitive/v=1
-tmpSenEmbeddingDataS3Path: configdata/experiment/yison-exp/audience/embedding_temp/RSMV2/sensitive/v=1
 embeddingDataS3Path: configdata/experiment/yison-exp/audience/embedding/RSMV2/v=1
-inferenceDataS3Path: data/experiment/yison-exp/audience/RSMV2/prediction

--- a/configs/prod/audience/CalibrationInputDataGeneratorJob/outputs.yml
+++ b/configs/prod/audience/CalibrationInputDataGeneratorJob/outputs.yml
@@ -1,2 +1,1 @@
-oosDataS3Path: data/prod/audience/RSMV2/Seed_None/v=1
 calibrationOutputDataS3Path: data/prod/audience/RSMV2/Seed_None/v=1

--- a/configs/prod/audience/EmbeddingMergeJob/behavioral_config.yml
+++ b/configs/prod/audience/EmbeddingMergeJob/behavioral_config.yml
@@ -8,3 +8,6 @@ locationFactor: 0.8
 baselineHitRate: 1e-08
 recursiveWeight: 0.1
 writeMode: overwrite
+tmpNonSenEmbeddingDataS3Path: configdata/prod/audience/embedding_temp/RSMV2/nonsensitive/v=1
+tmpSenEmbeddingDataS3Path: configdata/prod/audience/embedding_temp/RSMV2/sensitive/v=1
+inferenceDataS3Path: data/prod/audience/RSMV2/prediction

--- a/configs/prod/audience/EmbeddingMergeJob/outputs.yml
+++ b/configs/prod/audience/EmbeddingMergeJob/outputs.yml
@@ -1,4 +1,1 @@
-tmpNonSenEmbeddingDataS3Path: configdata/prod/audience/embedding_temp/RSMV2/nonsensitive/v=1
-tmpSenEmbeddingDataS3Path: configdata/prod/audience/embedding_temp/RSMV2/sensitive/v=1
 embeddingDataS3Path: configdata/prod/audience/embedding/RSMV2/v=1
-inferenceDataS3Path: data/prod/audience/RSMV2/prediction

--- a/configs/test/yison-exp/audience/CalibrationInputDataGeneratorJob/outputs.yml
+++ b/configs/test/yison-exp/audience/CalibrationInputDataGeneratorJob/outputs.yml
@@ -1,2 +1,1 @@
-oosDataS3Path: data/test/yison-exp/audience/RSMV2/Seed_None/v=1
 calibrationOutputDataS3Path: data/test/yison-exp/audience/RSMV2/Seed_None/v=1

--- a/configs/test/yison-exp/audience/EmbeddingMergeJob/behavioral_config.yml
+++ b/configs/test/yison-exp/audience/EmbeddingMergeJob/behavioral_config.yml
@@ -9,3 +9,6 @@ locationFactor: 0.8
 baselineHitRate: 1e-08
 recursiveWeight: 0.1
 writeMode: overwrite
+tmpNonSenEmbeddingDataS3Path: configdata/test/yison-exp/audience/embedding_temp/RSMV2/nonsensitive/v=1
+tmpSenEmbeddingDataS3Path: configdata/test/yison-exp/audience/embedding_temp/RSMV2/sensitive/v=1
+inferenceDataS3Path: data/test/yison-exp/audience/RSMV2/prediction

--- a/configs/test/yison-exp/audience/EmbeddingMergeJob/outputs.yml
+++ b/configs/test/yison-exp/audience/EmbeddingMergeJob/outputs.yml
@@ -1,4 +1,1 @@
-tmpNonSenEmbeddingDataS3Path: configdata/test/yison-exp/audience/embedding_temp/RSMV2/nonsensitive/v=1
-tmpSenEmbeddingDataS3Path: configdata/test/yison-exp/audience/embedding_temp/RSMV2/sensitive/v=1
 embeddingDataS3Path: configdata/test/yison-exp/audience/embedding/RSMV2/v=1
-inferenceDataS3Path: data/test/yison-exp/audience/RSMV2/prediction

--- a/generate_configs.py
+++ b/generate_configs.py
@@ -160,13 +160,13 @@ def generate_all(env_filter='all', exp_filter='all'):
                     data.setdefault('experimentName', exp_name)
                 else:
                     data.pop('experimentName', None)
-                # Default partition for writing output data. Combine the
+                # Default namespace for reading and writing data. Combine the
                 # environment and experiment name when available.
                 if exp_name:
                     partition = f"{env_name}/{exp_name}"
                 else:
                     partition = env_name
-                data.setdefault('data_write_partition', partition)
+                data.setdefault('data_namespace', partition)
                 out_dir = os.path.join(OUTPUT_ROOT, env_path, group, job_name)
                 os.makedirs(out_dir, exist_ok=True)
                 out_path = os.path.join(out_dir, filename)


### PR DESCRIPTION
## Summary
- use `data_namespace` as the single data partition variable
- update all audience templates to reference `data_namespace`
- regenerate configs
- move temporary embedding paths to `EmbeddingMergeJob` behavioral config

## Testing
- `make clean`
- `make build env=all`


------
https://chatgpt.com/codex/tasks/task_e_685e3098a3f08326bd7ffd0efa7ae7c9