### PR TITLE
Add date_time placeholder default

### DIFF
--- a/config-templates/audience/CalibrationInputDataGeneratorJob/behavioral_config.yml.j2
+++ b/config-templates/audience/CalibrationInputDataGeneratorJob/behavioral_config.yml.j2
@@ -6,6 +6,7 @@ model: "{{ model | default('RSMV2') }}"
 tag: "{{ tag | default('Seed_None') }}"
 version: {{ version | default(1) }}
 lookBack: {{ lookBack | default(3) }}
+date: "{{ date | default(run_date) }}"
 startDate: "{{ startDate | default('2025-02-13') }}"
 oosDataS3Bucket: "{{ oosDataS3Bucket | default('thetradedesk-mlplatform-us-east-1') }}"
 subFolderKey: "{{ subFolderKey | default('mixedForward') }}"

--- a/config-templates/audience/Imp2BrModelInferenceDataGenerator/behavioral_config.yml.j2
+++ b/config-templates/audience/Imp2BrModelInferenceDataGenerator/behavioral_config.yml.j2
@@ -3,7 +3,7 @@ environment: {{ environment }}
 experimentName: {{ experimentName }}
 {% endif %}
 bidImpressionsS3Path: "{{ bidImpressionsS3Path | default('prod/bidsimpressions/') }}"
-feature_path: "{{ feature_path | default('s3://thetradedesk-mlplatform-us-east-1/models/prod/RSM/full_model/' ~ date_time.strftime(version_date_format) ~ '/features.json') }}"
+feature_path: "{{ feature_path | default('s3://thetradedesk-mlplatform-us-east-1/models/prod/RSM/full_model/' ~ run_date.strftime(version_date_format) ~ '/features.json') }}"
 
 audienceJarBranch: "{{ audienceJarBranch | default('master') }}"
 audienceJarVersion: "{{ audienceJarVersion | default('latest') }}"

--- a/config-templates/audience/RelevanceModelInputGenerator/outputs.yml.j2
+++ b/config-templates/audience/RelevanceModelInputGenerator/outputs.yml.j2
@@ -1,2 +1,2 @@
-rsmV2FeatureDestPath: "{{ rsmV2FeatureDestPath | default('s3a://thetradedesk-mlplatform-us-east-1/configdata/' ~ data_namespace ~ '/audience/schema/RSMV2/v=1/' ~ date_time.strftime(version_date_format) ~ '/features.json') }}"
-optInSeedEmptyTagPath: "{{ optInSeedEmptyTagPath | default('s3a://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/RSMV2/Seed_None/v=1/' ~ date_time.strftime(version_date_format) ~ '/_' ~ (subFolder | default('Full')) ~ '_EMPTY') }}"
+rsmV2FeatureDestPath: "{{ rsmV2FeatureDestPath | default('s3a://thetradedesk-mlplatform-us-east-1/configdata/' ~ data_namespace ~ '/audience/schema/RSMV2/v=1/' ~ run_date.strftime(version_date_format) ~ '/features.json') }}"
+optInSeedEmptyTagPath: "{{ optInSeedEmptyTagPath | default('s3a://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/RSMV2/Seed_None/v=1/' ~ run_date.strftime(version_date_format) ~ '/_' ~ (subFolder | default('Full')) ~ '_EMPTY') }}"

--- a/config-templates/audience/TdidSeedScoreScale/behavioral_config.yml.j2
+++ b/config-templates/audience/TdidSeedScoreScale/behavioral_config.yml.j2
@@ -3,9 +3,9 @@ environment: {{ environment }}
 experimentName: {{ experimentName }}
 {% endif %}
 salt: "{{ salt | default('TRM') }}"
-seed_id_path: "{{ seed_id_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/seedids/v=2/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
-raw_score_path: "{{ raw_score_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/tdid2seedid_raw/v=1/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
-policy_table_path: "{{ policy_table_path | default('s3://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/policyTable/RSM/v=1/' ~ date_time.strftime(version_date_format) ~ '000000/') }}"
+seed_id_path: "{{ seed_id_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/seedids/v=2/date=' ~ run_date.strftime(version_date_format) ~ '/') }}"
+raw_score_path: "{{ raw_score_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/tdid2seedid_raw/v=1/date=' ~ run_date.strftime(version_date_format) ~ '/') }}"
+policy_table_path: "{{ policy_table_path | default('s3://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/policyTable/RSM/v=1/' ~ run_date.strftime(version_date_format) ~ '000000/') }}"
 smooth_factor: {{ smooth_factor | default(30.0) }}
 userLevelUpperCap: {{ userLevelUpperCap | default(1000000.0) }}
 accuracy: {{ accuracy | default(1000) }}

--- a/config-templates/audience/TdidSeedScoreScale/outputs.yml.j2
+++ b/config-templates/audience/TdidSeedScoreScale/outputs.yml.j2
@@ -1,2 +1,2 @@
-out_path: "{{ out_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/tdid2seedid/v=1/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
-population_score_path: "{{ population_score_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/seedpopulationscore/v=1/date=' ~ date_time.strftime(version_date_format) ~ '/') }}"
+out_path: "{{ out_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/tdid2seedid/v=1/date=' ~ run_date.strftime(version_date_format) ~ '/') }}"
+population_score_path: "{{ population_score_path | default('s3://thetradedesk-mlplatform-us-east-1/data/' ~ data_namespace ~ '/audience/scores/seedpopulationscore/v=1/date=' ~ run_date.strftime(version_date_format) ~ '/') }}"

--- a/configs/experiment/yanan-demo/audience/CalibrationInputDataGeneratorJob/behavioral_config.yml
+++ b/configs/experiment/yanan-demo/audience/CalibrationInputDataGeneratorJob/behavioral_config.yml
@@ -4,6 +4,7 @@ model: RSMV2
 tag: Seed_None
 version: 1
 lookBack: 7
+date: '{{ run_date }}'
 startDate: '2025-02-13'
 oosDataS3Bucket: thetradedesk-mlplatform-us-east-1
 subFolderKey: mixedForward

--- a/configs/experiment/yanan-demo/audience/Imp2BrModelInferenceDataGenerator/behavioral_config.yml
+++ b/configs/experiment/yanan-demo/audience/Imp2BrModelInferenceDataGenerator/behavioral_config.yml
@@ -2,6 +2,6 @@ environment: experiment
 experimentName: yanan-demo
 bidImpressionsS3Path: prod/bidsimpressions/
 feature_path: s3://thetradedesk-mlplatform-us-east-1/models/prod/RSM/full_model/{{
-  date_time.strftime('%Y%m%d') }}/features.json
+  run_date.strftime('%Y%m%d') }}/features.json
 audienceJarBranch: master
 audienceJarVersion: latest

--- a/configs/experiment/yanan-demo/audience/RelevanceModelInputGenerator/outputs.yml
+++ b/configs/experiment/yanan-demo/audience/RelevanceModelInputGenerator/outputs.yml
@@ -1,4 +1,4 @@
 rsmV2FeatureDestPath: s3a://thetradedesk-mlplatform-us-east-1/configdata/experiment/yanan-demo/audience/schema/RSMV2/v=1/{{
-  date_time.strftime('%Y%m%d') }}/features.json
+  run_date.strftime('%Y%m%d') }}/features.json
 optInSeedEmptyTagPath: s3a://thetradedesk-mlplatform-us-east-1/data/experiment/yanan-demo/audience/RSMV2/Seed_None/v=1/{{
-  date_time.strftime('%Y%m%d') }}/_Full_EMPTY
+  run_date.strftime('%Y%m%d') }}/_Full_EMPTY

--- a/configs/experiment/yanan-demo/audience/TdidSeedScoreScale/behavioral_config.yml
+++ b/configs/experiment/yanan-demo/audience/TdidSeedScoreScale/behavioral_config.yml
@@ -2,11 +2,11 @@ environment: experiment
 experimentName: yanan-demo
 salt: TRM
 seed_id_path: s3://thetradedesk-mlplatform-us-east-1/data/experiment/yanan-demo/audience/scores/seedids/v=2/date={{
-  date_time.strftime('%Y%m%d') }}/
+  run_date.strftime('%Y%m%d') }}/
 raw_score_path: s3://thetradedesk-mlplatform-us-east-1/data/experiment/yanan-demo/audience/scores/tdid2seedid_raw/v=1/date={{
-  date_time.strftime('%Y%m%d') }}/
+  run_date.strftime('%Y%m%d') }}/
 policy_table_path: s3://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/policyTable/RSM/v=1/{{
-  date_time.strftime('%Y%m%d') }}000000/
+  run_date.strftime('%Y%m%d') }}000000/
 smooth_factor: 30.0
 userLevelUpperCap: 1000000.0
 accuracy: 1000

--- a/configs/experiment/yanan-demo/audience/TdidSeedScoreScale/outputs.yml
+++ b/configs/experiment/yanan-demo/audience/TdidSeedScoreScale/outputs.yml
@@ -1,4 +1,4 @@
 out_path: s3://thetradedesk-mlplatform-us-east-1/data/experiment/yanan-demo/audience/scores/tdid2seedid/v=1/date={{
-  date_time.strftime('%Y%m%d') }}/
+  run_date.strftime('%Y%m%d') }}/
 population_score_path: s3://thetradedesk-mlplatform-us-east-1/data/experiment/yanan-demo/audience/scores/seedpopulationscore/v=1/date={{
-  date_time.strftime('%Y%m%d') }}/
+  run_date.strftime('%Y%m%d') }}/

--- a/configs/prod/audience/CalibrationInputDataGeneratorJob/behavioral_config.yml
+++ b/configs/prod/audience/CalibrationInputDataGeneratorJob/behavioral_config.yml
@@ -3,6 +3,7 @@ model: RSMV2
 tag: Seed_None
 version: 1
 lookBack: 3
+date: '{{ run_date }}'
 startDate: '2025-02-13'
 oosDataS3Bucket: thetradedesk-mlplatform-us-east-1
 subFolderKey: mixedForward

--- a/configs/prod/audience/Imp2BrModelInferenceDataGenerator/behavioral_config.yml
+++ b/configs/prod/audience/Imp2BrModelInferenceDataGenerator/behavioral_config.yml
@@ -1,6 +1,6 @@
 environment: prod
 bidImpressionsS3Path: prod/bidsimpressions/
 feature_path: s3://thetradedesk-mlplatform-us-east-1/models/prod/RSM/full_model/{{
-  date_time.strftime('%Y%m%d') }}/features.json
+  run_date.strftime('%Y%m%d') }}/features.json
 audienceJarBranch: master
 audienceJarVersion: latest

--- a/configs/prod/audience/RelevanceModelInputGenerator/outputs.yml
+++ b/configs/prod/audience/RelevanceModelInputGenerator/outputs.yml
@@ -1,4 +1,4 @@
 rsmV2FeatureDestPath: s3a://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/schema/RSMV2/v=1/{{
-  date_time.strftime('%Y%m%d') }}/features.json
+  run_date.strftime('%Y%m%d') }}/features.json
 optInSeedEmptyTagPath: s3a://thetradedesk-mlplatform-us-east-1/data/prod/audience/RSMV2/Seed_None/v=1/{{
-  date_time.strftime('%Y%m%d') }}/_Full_EMPTY
+  run_date.strftime('%Y%m%d') }}/_Full_EMPTY

--- a/configs/prod/audience/TdidSeedScoreScale/behavioral_config.yml
+++ b/configs/prod/audience/TdidSeedScoreScale/behavioral_config.yml
@@ -1,11 +1,11 @@
 environment: prod
 salt: TRM
 seed_id_path: s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/scores/seedids/v=2/date={{
-  date_time.strftime('%Y%m%d') }}/
+  run_date.strftime('%Y%m%d') }}/
 raw_score_path: s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/scores/tdid2seedid_raw/v=1/date={{
-  date_time.strftime('%Y%m%d') }}/
+  run_date.strftime('%Y%m%d') }}/
 policy_table_path: s3://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/policyTable/RSM/v=1/{{
-  date_time.strftime('%Y%m%d') }}000000/
+  run_date.strftime('%Y%m%d') }}000000/
 smooth_factor: 30.0
 userLevelUpperCap: 1000000.0
 accuracy: 1000

--- a/configs/prod/audience/TdidSeedScoreScale/outputs.yml
+++ b/configs/prod/audience/TdidSeedScoreScale/outputs.yml
@@ -1,4 +1,4 @@
 out_path: s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/scores/tdid2seedid/v=1/date={{
-  date_time.strftime('%Y%m%d') }}/
+  run_date.strftime('%Y%m%d') }}/
 population_score_path: s3://thetradedesk-mlplatform-us-east-1/data/prod/audience/scores/seedpopulationscore/v=1/date={{
-  date_time.strftime('%Y%m%d') }}/
+  run_date.strftime('%Y%m%d') }}/

--- a/configs/test/yanan-demo/audience/CalibrationInputDataGeneratorJob/behavioral_config.yml
+++ b/configs/test/yanan-demo/audience/CalibrationInputDataGeneratorJob/behavioral_config.yml
@@ -4,6 +4,7 @@ model: RSMV2
 tag: Seed_None
 version: 1
 lookBack: 5
+date: '{{ run_date }}'
 startDate: '2025-02-13'
 oosDataS3Bucket: thetradedesk-mlplatform-us-east-1
 subFolderKey: mixedForward

--- a/configs/test/yanan-demo/audience/Imp2BrModelInferenceDataGenerator/behavioral_config.yml
+++ b/configs/test/yanan-demo/audience/Imp2BrModelInferenceDataGenerator/behavioral_config.yml
@@ -2,6 +2,6 @@ environment: test
 experimentName: yanan-demo
 bidImpressionsS3Path: prod/bidsimpressions/
 feature_path: s3://thetradedesk-mlplatform-us-east-1/models/prod/RSM/full_model/{{
-  date_time.strftime('%Y%m%d') }}/features.json
+  run_date.strftime('%Y%m%d') }}/features.json
 audienceJarBranch: master
 audienceJarVersion: latest

--- a/configs/test/yanan-demo/audience/RelevanceModelInputGenerator/outputs.yml
+++ b/configs/test/yanan-demo/audience/RelevanceModelInputGenerator/outputs.yml
@@ -1,4 +1,4 @@
 rsmV2FeatureDestPath: s3a://thetradedesk-mlplatform-us-east-1/configdata/test/yanan-demo/audience/schema/RSMV2/v=1/{{
-  date_time.strftime('%Y%m%d') }}/features.json
+  run_date.strftime('%Y%m%d') }}/features.json
 optInSeedEmptyTagPath: s3a://thetradedesk-mlplatform-us-east-1/data/test/yanan-demo/audience/RSMV2/Seed_None/v=1/{{
-  date_time.strftime('%Y%m%d') }}/_Full_EMPTY
+  run_date.strftime('%Y%m%d') }}/_Full_EMPTY

--- a/configs/test/yanan-demo/audience/TdidSeedScoreScale/behavioral_config.yml
+++ b/configs/test/yanan-demo/audience/TdidSeedScoreScale/behavioral_config.yml
@@ -2,11 +2,11 @@ environment: test
 experimentName: yanan-demo
 salt: TRM
 seed_id_path: s3://thetradedesk-mlplatform-us-east-1/data/test/yanan-demo/audience/scores/seedids/v=2/date={{
-  date_time.strftime('%Y%m%d') }}/
+  run_date.strftime('%Y%m%d') }}/
 raw_score_path: s3://thetradedesk-mlplatform-us-east-1/data/test/yanan-demo/audience/scores/tdid2seedid_raw/v=1/date={{
-  date_time.strftime('%Y%m%d') }}/
+  run_date.strftime('%Y%m%d') }}/
 policy_table_path: s3://thetradedesk-mlplatform-us-east-1/configdata/prod/audience/policyTable/RSM/v=1/{{
-  date_time.strftime('%Y%m%d') }}000000/
+  run_date.strftime('%Y%m%d') }}000000/
 smooth_factor: 30.0
 userLevelUpperCap: 1000000.0
 accuracy: 1000

--- a/configs/test/yanan-demo/audience/TdidSeedScoreScale/outputs.yml
+++ b/configs/test/yanan-demo/audience/TdidSeedScoreScale/outputs.yml
@@ -1,4 +1,4 @@
 out_path: s3://thetradedesk-mlplatform-us-east-1/data/test/yanan-demo/audience/scores/tdid2seedid/v=1/date={{
-  date_time.strftime('%Y%m%d') }}/
+  run_date.strftime('%Y%m%d') }}/
 population_score_path: s3://thetradedesk-mlplatform-us-east-1/data/test/yanan-demo/audience/scores/seedpopulationscore/v=1/date={{
-  date_time.strftime('%Y%m%d') }}/
+  run_date.strftime('%Y%m%d') }}/

--- a/generate_configs.py
+++ b/generate_configs.py
@@ -28,15 +28,15 @@ import yaml
 from jinja2 import Environment, FileSystemLoader, StrictUndefined, exceptions
 
 
-class DateTimePlaceholder:
-    """Object that renders Jinja placeholders for date_time."""
+class RunDatePlaceholder:
+    """Object that renders Jinja placeholders for run_date."""
 
     def __str__(self):
-        return "{{ date_time }}"
+        return "{{ run_date }}"
 
     def strftime(self, fmt):
         # Preserve the formatting expression for run time resolution
-        return f"{{{{ date_time.strftime('{fmt}') }}}}"
+        return f"{{{{ run_date.strftime('{fmt}') }}}}"
 
 
 class Env(str, Enum):
@@ -60,8 +60,8 @@ jinja_env = Environment(
     undefined=StrictUndefined,
 )
 jinja_env.globals.update(
-    # Use a placeholder so date_time is resolved at run time
-    date_time=DateTimePlaceholder(),
+    # Use a placeholder so run_date is resolved at run time
+    run_date=RunDatePlaceholder(),
     version_date_format='%Y%m%d',
 )
 


### PR DESCRIPTION
## Summary
- default `run_date` placeholder in CalibrationInputDataGeneratorJob template
- rename date_time placeholder to run_date everywhere
- regenerate configs for the new placeholder

## Testing
- `make build env=all`


------
https://chatgpt.com/codex/tasks/task_e_68767b3c920c8326bd6abea9f535df3b